### PR TITLE
Update naming

### DIFF
--- a/pyroc/__init__.py
+++ b/pyroc/__init__.py
@@ -1,6 +1,6 @@
 """PyROC - A Python library for computing ROC curves."""
 
-__version__ = '0.0.9'
+__version__ = '0.0.10'
 
 from .roc import ROC
 from .bootstrap import bootstrap_roc

--- a/pyroc/compare.py
+++ b/pyroc/compare.py
@@ -105,8 +105,8 @@ def compare_binary(
         aucs_diff = [auc11 - auc21, auc12 - auc22, ..., auc1n - auc2n],
 
     where auc1i is the AUC of ith bootstrap of roc1, and auc2i is the AUC of
-    the ith bootstrap of roc2. We define the statistical strength, i.e.
-    p-value, for which we can reject the zero hypothesis roc1 > roc2 as
+    the ith bootstrap of roc2. We define the p-value, for which we can reject
+    the zero hypothesis roc1 > roc2 as
 
         p_value = sum(aucs_diff > 0) / n.
 

--- a/pyroc/roc.py
+++ b/pyroc/roc.py
@@ -22,8 +22,8 @@ class ROC():
     estimates
         List of Numpy array of Estimates corresponding to the ground truth
         values. Can be either integers, floats, or booleans.
-    stat_strength
-        Statistical strength, used when comparing to other ROC curves.
+    p_value
+        P-value used when comparing to other ROC curves.
 
     Raises
     ------
@@ -36,10 +36,10 @@ class ROC():
     def __init__(self,
                  ground_truth: Union[List[Union[int, float, bool]], np.array],
                  estimates: Union[List[Union[int, float, bool]], np.array],
-                 stat_strength: float = 0.05) -> None:
+                 p_value: float = 0.05) -> None:
         self.ground_truth = np.array(ground_truth).astype(np.int)
         self.estimates = np.array(estimates).astype(np.float)
-        self.stat_strength = stat_strength
+        self.p_value = p_value
 
         if np.isnan(self.ground_truth).any() or np.isnan(self.estimates).any():
             raise ValueError('Ground truth or estimates contain NaN values')
@@ -51,6 +51,9 @@ class ROC():
         if len(self.ground_truth) < 2:
             raise ValueError('Ground truth and estimates cannot have size zero'
                              ' or one.')
+
+        if not 0.0 <= self.p_value <= 1.0:
+            raise ValueError('P-value should be between 0 and 1.')
 
         self.tps = None
         self.fps = None
@@ -70,7 +73,7 @@ class ROC():
             raise NotImplementedError
         # Import here to avoid cross reference imports
         from pyroc import compare_bootstrap
-        comb_p_value = min(self.stat_strength, other.stat_strength)
+        comb_p_value = min(self.p_value, other.p_value)
         return compare_bootstrap(other, self, seed=37,
                                  alt_hypothesis=comb_p_value)[0]
 
@@ -84,7 +87,7 @@ class ROC():
             raise NotImplementedError
         # Import here to avoid cross reference imports
         from pyroc import compare_bootstrap
-        comb_p_value = min(self.stat_strength, other.stat_strength)
+        comb_p_value = min(self.p_value, other.p_value)
         return compare_bootstrap(self, other, seed=37,
                                  alt_hypothesis=comb_p_value)[0]
 

--- a/tests/test_roc.py
+++ b/tests/test_roc.py
@@ -231,7 +231,7 @@ class TestROCCompare(unittest.TestCase):
         self.roc2 = ROC([True, True, True, False, False, False],
                         [.9, .8, .35, .4, .3, .1])
         self.roc3 = ROC([True, True, True, False, False, False],
-                        [.9, .8, .35, .4, .3, .1], stat_strength=0.01)
+                        [.9, .8, .35, .4, .3, .1], p_value=0.01)
 
     def test_equal(self):
         assert self.roc1 == self.roc1
@@ -253,7 +253,7 @@ class TestROCCompare(unittest.TestCase):
         assert self.roc2 >= self.roc1
         assert not (self.roc2 <= self.roc1)
 
-        # ROC1 is not smaller than ROC3, because of the statistical strength.
+        # ROC1 is not smaller than ROC3, because of the p-value of 0.01.
         assert not (self.roc1 < self.roc3)
         assert not (self.roc3 > self.roc3)
         assert not (self.roc1 <= self.roc3)


### PR DESCRIPTION
Rename statistical strength to p-value. I could be that we're now using p-value the other way around. I.e. a statistical strength of 0.05 should be a p-value of 0.95. I don't know for sure. This is something to figure out at a later stage.